### PR TITLE
Add a missing semi-colon

### DIFF
--- a/lib/buildpack/release/releaser.rb
+++ b/lib/buildpack/release/releaser.rb
@@ -36,7 +36,7 @@ module AspNet5Buildpack
       FileUtils.mkdir_p(File.dirname(startup_script))
       File.open(startup_script, 'w') do |f|
         f.write 'export HOME=/app;'
-        f.write 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/libuv/lib:$HOME/libunwind/lib:$HOME/odbc_cli/clidriver/lib'
+        f.write 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/libuv/lib:$HOME/libunwind/lib:$HOME/odbc_cli/clidriver/lib;'
         f.write '[ -f $HOME/.dnx/dnvm/dnvm.sh ] && { source $HOME/.dnx/dnvm/dnvm.sh; dnvm use default; }'
       end
     end


### PR DESCRIPTION
When the write_startup_script method writes the script, it does not add a new-line character automatically.  Therefore, each line has to end in a semi-colon for the script to run properly.
